### PR TITLE
Ensure viewport unit prefers dvh when supported

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -25,15 +25,15 @@
   }
 }
 
-@supports (height: 100lvh) {
+@supports (height: 100dvh) {
   :root {
-    --viewport-effects-unit: 1lvh;
+    --viewport-unit: 1dvh;
   }
 }
 
-@supports (height: 100dvh) and not (height: 100svh) {
+@supports (height: 100lvh) {
   :root {
-    --viewport-unit: 1dvh;
+    --viewport-effects-unit: 1lvh;
   }
 }
 


### PR DESCRIPTION
## Summary
- reorder viewport-related @supports blocks so that browsers using dynamic viewport units set `--viewport-unit` to `1dvh`
- keep layout sections relying on `--viewport-unit` continuing to expand to the full viewport height

## Testing
- not run (iOS Safari/Chrome not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cfe8920e708331901d3390272623b9