### PR TITLE
Ensure viewport effect unit tracks visual viewport

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -25,9 +25,9 @@
   }
 }
 
-@supports (height: 100lvh) {
+@supports (height: 100dvh) {
   :root {
-    --viewport-effects-unit: 1lvh;
+    --viewport-effects-unit: 1dvh;
   }
 }
 


### PR DESCRIPTION
## Summary
- keep the viewport effect variable in sync with the visual viewport even when dynamic viewport units are supported
- share initialization through a dynamic path that broadcasts height updates and cleans up listeners symmetrically with the legacy fallback
- rely on CSS `dvh` units for the overscroll effects variable when supported

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cfe892f38c8331b1c0ad63b128ab95