### PR TITLE
Ensure dynamic viewport helper updates both custom units

### DIFF
--- a/script.js
+++ b/script.js
@@ -439,9 +439,10 @@
 
     const bindings = [];
 
-    const updateDynamicViewportEffects = () => {
+    const updateDynamicViewportUnits = () => {
+      const visualViewportHeight = window.visualViewport?.height;
       const height = pickDimension([
-        window.visualViewport?.height,
+        visualViewportHeight,
         window.innerHeight,
         document.documentElement?.clientHeight,
       ]);
@@ -450,8 +451,7 @@
         return;
       }
 
-      applyViewportEffectsHeight(height, { resolved: true });
-      broadcastViewportHeight(height);
+      applyViewportHeight(height);
     };
 
     const addListener = (target, type) => {
@@ -459,9 +459,9 @@
         return;
       }
 
-      target.addEventListener(type, updateDynamicViewportEffects);
+      target.addEventListener(type, updateDynamicViewportUnits);
       bindings.push(() => {
-        target.removeEventListener(type, updateDynamicViewportEffects);
+        target.removeEventListener(type, updateDynamicViewportUnits);
       });
     };
 
@@ -472,7 +472,7 @@
       addListener(window.visualViewport, 'resize');
     }
 
-    updateDynamicViewportEffects();
+    updateDynamicViewportUnits();
 
     window.__viewportUnitCleanup = () => {
       while (bindings.length) {


### PR DESCRIPTION
## Summary
- update the dynamic viewport helper to drive both custom viewport CSS variables from the current visual viewport height
- keep the dynamic branch broadcasting viewport height updates when modern viewport units are supported

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cfec5fb3008331a95ff5c8a9658041