### PR TITLE
Refine mobile edge overlays

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,8 @@
 </head>
 <body>
   <div class="backdrop" aria-hidden="true"></div>
+  <div class="mobile-edge mobile-edge--top" aria-hidden="true"></div>
+  <div class="mobile-edge mobile-edge--bottom" aria-hidden="true"></div>
 
   <header class="site-header">
     <div class="site-header__inner">

--- a/script.js
+++ b/script.js
@@ -439,9 +439,10 @@
 
     const bindings = [];
 
-    const updateDynamicViewportEffects = () => {
+    const updateDynamicViewportUnits = () => {
+      const visualViewportHeight = window.visualViewport?.height;
       const height = pickDimension([
-        window.visualViewport?.height,
+        visualViewportHeight,
         window.innerHeight,
         document.documentElement?.clientHeight,
       ]);
@@ -450,8 +451,7 @@
         return;
       }
 
-      applyViewportEffectsHeight(height, { resolved: true });
-      broadcastViewportHeight(height);
+      applyViewportHeight(height);
     };
 
     const addListener = (target, type) => {
@@ -459,9 +459,9 @@
         return;
       }
 
-      target.addEventListener(type, updateDynamicViewportEffects);
+      target.addEventListener(type, updateDynamicViewportUnits);
       bindings.push(() => {
-        target.removeEventListener(type, updateDynamicViewportEffects);
+        target.removeEventListener(type, updateDynamicViewportUnits);
       });
     };
 
@@ -472,7 +472,7 @@
       addListener(window.visualViewport, 'resize');
     }
 
-    updateDynamicViewportEffects();
+    updateDynamicViewportUnits();
 
     window.__viewportUnitCleanup = () => {
       while (bindings.length) {

--- a/styles.css
+++ b/styles.css
@@ -9,6 +9,17 @@
   --viewport-effects-unit: 1vh;
   --overscroll-bleed: clamp(120px, calc(var(--viewport-unit) * 16), 240px);
   --overscroll-effects-bleed: clamp(120px, calc(var(--viewport-effects-unit) * 16), 240px);
+  --edge-fade-height: clamp(160px, calc(var(--viewport-effects-unit) * 34), 360px);
+  --edge-ambient-height: clamp(200px, calc(var(--viewport-effects-unit) * 42), 420px);
+  --edge-fade-gradient-top: linear-gradient(to bottom, rgba(5, 5, 5, 0.9) 0%, rgba(5, 5, 5, 0) 60%);
+  --edge-fade-gradient-bottom: linear-gradient(to top, rgba(5, 5, 5, 0.9) 0%, rgba(5, 5, 5, 0) 60%);
+  --edge-ambient-gradient-bottom: linear-gradient(
+      to top,
+      rgba(5, 5, 5, 0.88) 0%,
+      rgba(5, 5, 5, 0.52) 45%,
+      rgba(5, 5, 5, 0.18) 85%,
+      rgba(5, 5, 5, 0) 100%
+    );
   --safe-area-top: 0px;
   --safe-area-right: 0px;
   --safe-area-bottom: 0px;
@@ -120,24 +131,18 @@ body::after {
   pointer-events: none;
   z-index: 2;
   background-image:
-    linear-gradient(to bottom, rgba(5, 5, 5, 0.9) 0%, rgba(5, 5, 5, 0) 60%),
-    linear-gradient(to top, rgba(5, 5, 5, 0.9) 0%, rgba(5, 5, 5, 0) 60%),
-    linear-gradient(
-      to top,
-      rgba(5, 5, 5, 0.88) 0%,
-      rgba(5, 5, 5, 0.52) 45%,
-      rgba(5, 5, 5, 0.18) 85%,
-      rgba(5, 5, 5, 0) 100%
-    );
+    var(--edge-fade-gradient-top),
+    var(--edge-fade-gradient-bottom),
+    var(--edge-ambient-gradient-bottom);
   background-position:
     center calc(var(--overscroll-effects-bleed) + var(--safe-area-top)),
     center calc(100% - (var(--overscroll-effects-bleed) + var(--safe-area-bottom))),
     center calc(100% - (var(--overscroll-effects-bleed) + var(--safe-area-bottom)));
   background-repeat: no-repeat;
   background-size:
-    100% calc(clamp(160px, calc(var(--viewport-effects-unit) * 34), 360px) + var(--safe-area-top)),
-    100% calc(clamp(160px, calc(var(--viewport-effects-unit) * 34), 360px) + var(--safe-area-bottom)),
-    100% calc(clamp(200px, calc(var(--viewport-effects-unit) * 42), 420px) + var(--safe-area-bottom));
+    100% calc(var(--edge-fade-height) + var(--safe-area-top)),
+    100% calc(var(--edge-fade-height) + var(--safe-area-bottom)),
+    100% calc(var(--edge-ambient-height) + var(--safe-area-bottom));
 }
 
 .backdrop {
@@ -159,6 +164,25 @@ body::after {
   mix-blend-mode: screen;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='240' height='240'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.5'/%3E%3C/svg%3E");
   background-size: 200px;
+}
+
+.mobile-edge {
+  position: fixed;
+  left: calc(var(--overscroll-effects-bleed) * -1 - var(--safe-area-left));
+  right: calc(var(--overscroll-effects-bleed) * -1 - var(--safe-area-right));
+  background: var(--background);
+  pointer-events: none;
+  z-index: 64;
+  display: none;
+  overflow: hidden;
+}
+
+.mobile-edge::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  pointer-events: none;
 }
 
 main,
@@ -588,6 +612,40 @@ body.is-menu-closing .site-menu-toggle__icon span:nth-child(3) {
 }
 
 @media (max-width: 720px) {
+  .mobile-edge {
+    display: block;
+  }
+
+  .mobile-edge--top {
+    top: calc(var(--overscroll-effects-bleed) * -1 - var(--safe-area-top));
+    height: calc(var(--overscroll-effects-bleed) + var(--safe-area-top) + var(--edge-fade-height));
+  }
+
+  .mobile-edge--top::after {
+    top: calc(var(--overscroll-effects-bleed) + var(--safe-area-top));
+    height: calc(var(--edge-fade-height) + var(--safe-area-top));
+    background-image: var(--edge-fade-gradient-top);
+    background-position: center top;
+    background-repeat: no-repeat;
+    background-size: 100% 100%;
+  }
+
+  .mobile-edge--bottom {
+    bottom: calc(var(--overscroll-effects-bleed) * -1 - var(--safe-area-bottom));
+    height: calc(var(--overscroll-effects-bleed) + var(--safe-area-bottom) + var(--edge-ambient-height));
+  }
+
+  .mobile-edge--bottom::after {
+    bottom: calc(var(--overscroll-effects-bleed) + var(--safe-area-bottom));
+    height: calc(var(--edge-ambient-height) + var(--safe-area-bottom));
+    background-image: var(--edge-fade-gradient-bottom), var(--edge-ambient-gradient-bottom);
+    background-position: center bottom, center bottom;
+    background-repeat: no-repeat;
+    background-size:
+      100% calc(var(--edge-fade-height) + var(--safe-area-bottom)),
+      100% calc(var(--edge-ambient-height) + var(--safe-area-bottom));
+  }
+
   .site-header {
     --site-header-padding-block: clamp(36px, calc(var(--viewport-unit) * 14), 80px);
     --site-header-padding-inline: clamp(20px, 10vw, 40px);


### PR DESCRIPTION
## Summary
- introduce shared edge fade variables to keep the pseudo-element gradients and mobile shims in sync with the background
- extend the mobile edge overlays across the overscroll bleed, raise their stacking order, and add matching gradients so the fades align with the text

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cfec5fb3008331a95ff5c8a9658041